### PR TITLE
Move `plugin` to named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ To use this plugin in your project, you have to apply the plugin to your applica
 
 ```typescript
 import { createApp } from 'vue';
-import Plugin from 'vue-viewmodel';
+import { plugin } from 'vue-viewmodel';
 import App from './App.vue'
 
 const app = createApp(App);
 // Apply this plugin to your application.
-app.use(Plugin);
+app.use(plugin);
 app.mount('#app');
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import Plugin from './plugin';
 
-const plugin = new Plugin();
-export default plugin;
+export const plugin = new Plugin();
 
 export {
   ViewModel,


### PR DESCRIPTION
## Proposed Changes

**BREAKING CHANGES** included.

- Instead of exporting the plugin instance by default exports, we use named exports for better CJS support.

That is, after this change, you should import the plugin as:

```diff
import { createApp } from 'vue';
-import Plugin from 'vue-viewmodel';
+import { plugin } from 'vue-viewmodel';
import App from './App.vue'

const app = createApp(App);
// Apply this plugin to your application.
-app.use(Plugin);
+app.use(plugin);
app.mount('#app');
```

The reason why don't use mixed exports:
https://rollupjs.org/guide/en/#outputexports