### PR TITLE
[BREAKING CHANGE] Provide the default implementation of `clear` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ export default class MyViewModel extends ViewModel {
   count = ref(0);
 
   clear() {
+    super.clear();
     // Release your resources and listeners *HERE*.
   }
 }

--- a/src/viewmodel.ts
+++ b/src/viewmodel.ts
@@ -12,7 +12,10 @@ export abstract class ViewModel {
    * This method will be called when the ViewModel is no longer needed and will
    * be destroyed. You should override this method to release resources.
    */
-  abstract clear(): void;
+  clear(): void {
+    // The empty implementation for the case the
+    // derived class didn't override `clear` method.
+  }
 }
 
 /**
@@ -176,6 +179,7 @@ export class ViewModelProvider {
  *   count = ref(0);
  *
  *   clear() {
+ *     super.clear();
  *     // ...
  *   }
  * }
@@ -197,6 +201,7 @@ export class ViewModelProvider {
  *   count = ref(0);
  *
  *   clear() {
+ *     super.clear();
  *     // ...
  *   }
  * }
@@ -224,6 +229,7 @@ export class ViewModelProvider {
  *   }
  *
  *   clear() {
+ *     super.clear();
  *     // ...
  *   }
  * }

--- a/test/helpers/TestCustomCtorViewModel.ts
+++ b/test/helpers/TestCustomCtorViewModel.ts
@@ -6,6 +6,7 @@ export default class TestCustomCtorViewModel extends ViewModel {
   }
 
   public clear(): void {
+    super.clear();
     console.log('clear called');
   }
 }

--- a/test/helpers/TestViewModel.ts
+++ b/test/helpers/TestViewModel.ts
@@ -4,6 +4,7 @@ export default class TestViewModel extends ViewModel {
   public count = 0;
 
   public clear(): void {
+    super.clear();
     console.log('clear called');
   }
 }


### PR DESCRIPTION
## Proposed Changes

**BREAKING CHANGE** included.

- Provide the default implementation of `clear` method in the abstruct class `ViewModel`.

Before this change, if you write a derived class without the `clear` implementation (even if you don't really need the implementation), it will leads to a exception when the viewmodel destroyed.

```typescript
export default class MyViewModel extends ViewModel {
  // without `clear` implementation.
}
```

![コメント 2020-11-01 164713](https://user-images.githubusercontent.com/4210652/97797641-f2739a80-1c61-11eb-81c9-c20bf0d65c3b.png)

To avoid this problem, we provided the empty default implementation of `clear` in `ViewModel`. So override the `clear` method could be a option. You can write a derived viewmodel class without the implementation of `clear` method if you don't need it.

Otherwise, if you provide a implementation of `clear`, you should alse call the `clear` method in the super class:

```typescript
export default class MyViewModel extends ViewModel {
  clear() {
    // Call the parent's method is the best practice.
    super.clear();
    // Release your resources and listeners *HERE*.
  }
}
```