### PR TITLE
Move `--coverage` flag from cli options to config file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
     // Set the path alias such that you can use like '@/foo' to reference 'src/foo'.
     '^@/(.*)$': '<rootDir>/src/$1',
   },
+  collectCoverage: true,
   collectCoverageFrom: ['src/**'],
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build",
     "lint": "eslint src/**",
     "lint:fix": "eslint --fix src/**",
-    "test": "jest --coverage"
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Proposed changes

As title, just move the flag from the `jest` CLI options to config file.

https://jestjs.io/docs/en/configuration#collectcoverage-boolean